### PR TITLE
adjust wget parser for improved performance

### DIFF
--- a/code/parsers/wget.py
+++ b/code/parsers/wget.py
@@ -45,9 +45,7 @@ class WgetParser(ParserBase):
 
     def get_document_dependencies(self, document: str) -> List[ExtractedDependency]:
         dependencies = []
-        print(f'Started blocks - {time.time()}')
         wget_blocks = self.wget_block_extractor_regex.findall(document)
-        print(f'ended blocks - {time.time()}')
         for block in wget_blocks:
             command = block[0]
             urls = self.url_extractor_regex.findall(command)

--- a/tests/automated_functional_test/test_configs/wget.yml
+++ b/tests/automated_functional_test/test_configs/wget.yml
@@ -364,13 +364,13 @@ config:
   expected_dependencies:
     - type: wget
       name:  latest.zip
-      version: https://wordpress.org/latest.zip
-      download_location: 198.143.164.252
+      version: unknown
+      download_location: https://wordpress.org/latest.zip
     - type: wget
       name:  wordpress-install.zip
-      version: https://wordpress.org/latest.zip
-      download_location: 198.143.164.252
+      version: unknown
+      download_location: https://wordpress.org/latest.zip
     - type: wget
       name:  wordpress-install-docker-linux.zip
-      version: https://wordpress.org/latest.zip
-      download_location: 198.143.164.252
+      version: unknown
+      download_location: https://wordpress.org/latest.zip


### PR DESCRIPTION
Previous wget parser regex was causing extreme backtracking issues, leading to 5+ minute runtimes for large log files. Improved performance and updated tests to account for different data extraction.