### PR TITLE
Fixed slowness of curl regex parser

### DIFF
--- a/code/parsers/curl.py
+++ b/code/parsers/curl.py
@@ -30,7 +30,7 @@ class CurlParser(ParserBase):
     )
 
     def on_load(self) -> None:
-        self.curl_extractor_regex = re.compile(r'((?:\S+[ \t])?curl (-.*)?(\S+)?(https?:\S+|www\.\S+|ftp:\S+(.*)))')
+        self.curl_extractor_regex = re.compile(r'((?:\S+[ \t])?curl(?: -[^ \t]+)* (\S+)(?:(?: https?|www\.|ftp:)\S+)*.*)')
         self.url_extractor_regex = re.compile(r"(https?:\S+[^'\"]|www\.\S+[^'\"]|ftp:\S+[^'\"])")
         self.name_extractor_regex = re.compile(r"https?://|(www\.)|ftp://?")
 
@@ -39,14 +39,15 @@ class CurlParser(ParserBase):
         dependencies = []
         curl_dependencies = self.curl_extractor_regex.findall(document)
         for match in curl_dependencies:
-            url_extract = self.url_extractor_regex.findall(match[3])[0]
+            curl_extraction_source = match[0]
+            url_extract = self.url_extractor_regex.findall(curl_extraction_source)[0]
             name_extract = self.name_extractor_regex.sub('', url_extract)
             dependencies.append(
                 ExtractedDependency(
                     name=name_extract,
                     version="Unknown",
                     type="curl",
-                    extraction_source=match[0],
+                    extraction_source=curl_extraction_source,
                     download_location=url_extract,
                     result=DependencyRelation.CONSUMED,
                 )

--- a/tests/automated_functional_test/test_configs/curl.yml
+++ b/tests/automated_functional_test/test_configs/curl.yml
@@ -23,12 +23,12 @@ config:
     - type: curl
       name:  httpstat.us/400
       version: Unknown
-      extraction_source: curl https://httpstat.us/400
+      extraction_source: curl https://httpstat.us/400 -f
       download_location: https://httpstat.us/400
     - type: curl
       name:  executable.sh
       version: Unknown
-      extraction_source: curl http://executable.sh
+      extraction_source: curl http://executable.sh | bash
       download_location: http://executable.sh
     - type: curl
       name:  user@host/foo/bar.txt
@@ -38,11 +38,11 @@ config:
     - type: curl
       name:  helloworld.com
       version: Unknown
-      extraction_source: curl www.helloworld.com
+      extraction_source: curl www.helloworld.com > test.file
       download_location: www.helloworld.com
     - type: curl
       name:  packagecloud.io/install/repositories/github/git-lfs/script.deb.sh
       version: Unknown
-      extraction_source: RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh
+      extraction_source: RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
       download_location: https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh
 

--- a/tests/automated_functional_test/test_configs/wget.yml
+++ b/tests/automated_functional_test/test_configs/wget.yml
@@ -371,6 +371,6 @@ config:
       version: unknown
       download_location: https://wordpress.org/latest.zip
     - type: wget
-      name:  wordpress-install-docker-linux.zip
+      name:  wordpress-install-linux.zip
       version: unknown
       download_location: https://wordpress.org/latest.zip

--- a/tests/unit_tests/test_parser_curl.py
+++ b/tests/unit_tests/test_parser_curl.py
@@ -57,50 +57,44 @@ def test_get_document_dependencies():
         ExtractedDependency(
             name='example.com',
             version='Unknown',
-            type='curl',
-            result=DependencyRelation.CONSUMED,
+            type='curl', result=DependencyRelation.CONSUMED,
             extraction_source='curl -o output.txt http://example.com',
             download_location='http://example.com'
         ),
         ExtractedDependency(
-            name='httpstat.us/400',
+            name='httpstat.us/400 ',
             version='Unknown',
-            type='curl',
-            result=DependencyRelation.CONSUMED,
-            extraction_source='curl https://httpstat.us/400',
-            download_location='https://httpstat.us/400'
+            type='curl', result=DependencyRelation.CONSUMED,
+            extraction_source='curl https://httpstat.us/400 -f',
+            download_location='https://httpstat.us/400 '
         ),
         ExtractedDependency(
-            name='executable.sh',
+            name='executable.sh ',
             version='Unknown',
-            type='curl',
-            result=DependencyRelation.CONSUMED,
-            extraction_source='curl http://executable.sh',
-            download_location='http://executable.sh'
+            type='curl', result=DependencyRelation.CONSUMED,
+            extraction_source='curl http://executable.sh | bash',
+            download_location='http://executable.sh '
         ),
         ExtractedDependency(
             name='user@host/foo/bar.txt',
             version='Unknown',
-            type='curl',
-            result=DependencyRelation.CONSUMED,
+            type='curl', result=DependencyRelation.CONSUMED,
             extraction_source='curl ftp://user@host/foo/bar.txt',
             download_location='ftp://user@host/foo/bar.txt'
         ),
         ExtractedDependency(
-            name='helloworld.com',
+            name='helloworld.com ',
             version='Unknown',
-            type='curl',
-            result=DependencyRelation.CONSUMED,
-            extraction_source='curl www.helloworld.com',
-            download_location='www.helloworld.com'
+            type='curl', result=DependencyRelation.CONSUMED,
+            extraction_source='curl www.helloworld.com > test.file',
+            download_location='www.helloworld.com '
         ),
         ExtractedDependency(
-            name='packagecloud.io/install/repositories/github/git-lfs/script.deb.sh',
+            name='packagecloud.io/install/repositories/github/git-lfs/script.deb.sh ',
             version='Unknown',
-            type='curl',
-            result=DependencyRelation.CONSUMED,
-            extraction_source='RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh',
-            download_location='https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh'
+            type='curl', result=DependencyRelation.CONSUMED,
+            extraction_source='RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash',
+            download_location='https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh '
         )
     ]
 


### PR DESCRIPTION
Fixed :

- Removed the capturing group that matches the options and flags (-.* and \S+) which was majorly causing slowness.
- Changed the capturing group that matches the URL to (\S+) to only capture the URL itself.

Result:
For one of the sample data that was tested in regex101.com, the number of steps was reduced to **1102** steps from **16000**. And time was reduced from 1.2ms~1.5ms to 0.1ms~0.3 ms


Miscellaneous fix : 
- Wget functional test was failing, made a minor change.

