### PR TITLE
Implement basic config file and parsing timeout logic

### DIFF
--- a/code/formatters/base.py
+++ b/code/formatters/base.py
@@ -11,11 +11,11 @@ class BaseFormatter(ABC):
     MIME_TYPE = None
 
     @abstractclassmethod
-    def format_findings(cls, findings: List[ExtractedFinding]):
+    def format_findings(cls, findings: List[ExtractedFinding], errors: List[str]):
         pass
 
     @abstractclassmethod
-    def format_dependencies(cls, dependencies: List[ExtractedDependency]):
+    def format_dependencies(cls, dependencies: List[ExtractedDependency], errors: List[str]):
         pass
 
     @abstractclassmethod

--- a/code/formatters/json.py
+++ b/code/formatters/json.py
@@ -10,12 +10,12 @@ class JsonFormatter(BaseFormatter):
     MIME_TYPE = 'application/json'
     
     @classmethod
-    def format_findings(cls, findings: List[ExtractedFinding]):
-        return dumps([finding.dict() for finding in findings])
+    def format_findings(cls, findings: List[ExtractedFinding], errors: List[str]):
+        return dumps({"findings":[finding.dict() for finding in findings],"errors":errors})
 
     @classmethod
-    def format_dependencies(cls, dependencies: List[ExtractedDependency]):
-        return dumps([dependency.dict() for dependency in dependencies])
+    def format_dependencies(cls, dependencies: List[ExtractedDependency], errors: List[str]):
+        return dumps({"dependencies":[dependency.dict() for dependency in dependencies],"errors":errors})
 
     @classmethod
     def format_report(cls, report: DocumentReport):

--- a/code/formatters/spdx.py
+++ b/code/formatters/spdx.py
@@ -55,7 +55,7 @@ class SPDXBaseFormatter(BaseFormatter):
     __TO_METHOD__ = None
 
     @classmethod
-    def format_findings(cls, findings: List[ExtractedFinding]):
+    def format_findings(cls, findings: List[ExtractedFinding], errors: List[str]):
         SPDX_document = create_base_spdx_document('LogFileSource')
         SPDX_document.package = Package(name=SPDX_document.name,spdx_id=SPDX_document.spdx_id)
         for finding in findings:
@@ -69,7 +69,7 @@ class SPDXBaseFormatter(BaseFormatter):
         return cls.__TO_METHOD__(SPDX_document)
 
     @classmethod
-    def format_dependencies(cls, dependencies: List[ExtractedDependency]):
+    def format_dependencies(cls, dependencies: List[ExtractedDependency], errors: List[str]):
         dependent_documents = []
         for dependency in dependencies:
             dep_document = create_base_spdx_document(dependency.name)

--- a/code/formatters/spdx.py
+++ b/code/formatters/spdx.py
@@ -109,8 +109,8 @@ class SPDXJsonFormatter(SPDXBaseFormatter):
     MIME_TYPE = 'application/json'
 
     @classmethod
-    def format_dependencies(cls, dependencies: List[ExtractedDependency]):
-        dependent_docs = super().format_dependencies(dependencies)
+    def format_dependencies(cls, dependencies: List[ExtractedDependency], errors: List[str]):
+        dependent_docs = super().format_dependencies(dependencies, errors)
         return_value = f"[{','.join([document_to_json(doc) for doc in dependent_docs])}]"
         return return_value
 
@@ -125,8 +125,8 @@ class SPDXXMLFormatter(SPDXBaseFormatter):
     __TO_METHOD__ = document_to_xml
 
     @classmethod
-    def format_dependencies(cls, dependencies: List[ExtractedDependency]):
-        dependent_docs = super().format_dependencies(dependencies)
+    def format_dependencies(cls, dependencies: List[ExtractedDependency], errors: List[str]):
+        dependent_docs = super().format_dependencies(dependencies, errors)
         return_value = '\n---\n'.join([document_to_xml(doc) for doc in dependent_docs])
         return return_value
 

--- a/code/models.py
+++ b/code/models.py
@@ -40,3 +40,4 @@ class ExtractedFinding(BaseModel):
 class DocumentReport(BaseModel):
     findings: List[ExtractedFinding]
     dependencies: List[ExtractedDependency]
+    errors: List[str]

--- a/code/settings.py
+++ b/code/settings.py
@@ -1,0 +1,22 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from typing import List
+import yaml
+import json
+from pydantic import BaseModel
+from os.path import isfile
+
+class Settings(BaseModel):
+    parser_timeout: int = 1                      # Max time for a single parser to run
+    disabled_parsers: List[str] = []             # List of parsers to disable
+
+    @classmethod
+    def load_from_file(cls, file_path: str = "defaults.yml"):
+        if isfile(file_path):
+            with open(file_path, 'r') as settings_file:
+                settings = yaml.load(settings_file, yaml.SafeLoader)
+            settings_obj = cls.parse_raw(json.dumps(settings))
+            return settings_obj
+        else:
+            return cls()

--- a/code/utils.py
+++ b/code/utils.py
@@ -10,7 +10,7 @@ class TimeoutExpiredError(Exception):
 def timeout(seconds: int=1):
     def decorator(func):
         def _handler(signum, frame):
-            raise TimeoutExpiredError((f'Function {func.__name__} timed out after {seconds} seconds.',func.__name__, seconds))
+            raise TimeoutExpiredError(f'Function {func.__name__} timed out after {seconds} seconds.',func.__name__, seconds)
         
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/code/utils.py
+++ b/code/utils.py
@@ -1,0 +1,27 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import functools
+import signal
+
+class TimeoutExpiredError(Exception):
+    pass
+
+def timeout(seconds: int=1):
+    def decorator(func):
+        def _handler(signum, frame):
+            raise TimeoutExpiredError((f'Function {func.__name__} timed out after {seconds} seconds.',func.__name__, seconds))
+        
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            signal.signal(signal.SIGALRM, _handler)
+            signal.alarm(seconds)
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+            return result
+        
+        return wrapper
+
+    return decorator

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,5 @@
+## Per-parser timeout when generating findings and dependencies (Seconds)
+parser_timeout: 10
+## List of parsers to disable
+disabled_parsers:
+  - CurlParser

--- a/tests/unit_tests/test_json_formatter.py
+++ b/tests/unit_tests/test_json_formatter.py
@@ -30,16 +30,21 @@ def test_format_findings():
         severity = FindingSeverity.INFORMATIONAL,
         category = "MOCK CATEGORY"
     )
+    MOCK_ERRORS = "MockError"
 
     # Act
-    result = JsonFormatter.format_findings([MOCK_FINDING])
+    result = JsonFormatter.format_findings([MOCK_FINDING], [MOCK_ERRORS])
 
     # Assert
     assert json.loads(result) # Is valid JSON data
     result_obj = json.loads(result)
-    assert isinstance(result_obj, list) # The return is a list
-    assert result_obj != [] # Is not blank
-    assert len(result_obj) == 1 # It has 1 finding
+    assert isinstance(result_obj, dict) # The return is a dictionary
+    assert result_obj != {} # Is not blank
+    assert len(result_obj.keys()) == 2 # It has 2 keys
+    assert "findings" in result_obj.keys()
+    assert len(result_obj['findings']) == 1
+    assert "errors" in result_obj.keys()
+    assert len(result_obj['errors']) == 1
 
 def test_format_dependencies():
     # Arrange
@@ -51,13 +56,18 @@ def test_format_dependencies():
         extraction_source = "MOCK SOURCE",
         download_location = "MOCK LOCATION"
     )
+    MOCK_ERRORS = "MockError"
 
     # Act
-    result = JsonFormatter.format_dependencies([MOCK_DEPENDENCY])
+    result = JsonFormatter.format_dependencies([MOCK_DEPENDENCY], [MOCK_ERRORS])
 
     # Assert
     assert json.loads(result) # Is valid JSON data
     result_obj = json.loads(result)
-    assert isinstance(result_obj, list) # The return is a list
-    assert result_obj != [] # Is not blank
-    assert len(result_obj) == 1 # It has 1 dependency
+    assert isinstance(result_obj, dict) # The return is a dictionary
+    assert result_obj != {} # Is not blank
+    assert len(result_obj.keys()) == 2 # It has 2 keys
+    assert "dependencies" in result_obj.keys()
+    assert len(result_obj['dependencies']) == 1
+    assert "errors" in result_obj.keys()
+    assert len(result_obj['errors']) == 1

--- a/tests/unit_tests/test_microservice.py
+++ b/tests/unit_tests/test_microservice.py
@@ -129,8 +129,9 @@ def test_generate_findings_buildlog(
     # Arrange
     POST_DATA = "This is a buildlog"
     TYPE = "buildlog"
-    EXPECTED_RETURN = []
-    mock_generate_findings.return_value = EXPECTED_RETURN
+    FINDINGS_RETURN = ([],[])
+    mock_generate_findings.return_value = FINDINGS_RETURN
+    EXPECTED_RETURN = {'errors': [], 'findings': []}
 
     # Act
     response = test_client.post(f"/v1/findings?type={TYPE}", POST_DATA)
@@ -160,8 +161,9 @@ def test_generate_deps_buildlog(
     # Arrange
     POST_DATA = "This is a buildlog"
     TYPE = "buildlog"
-    EXPECTED_RETURN = []
-    mock_generate_deps.return_value = EXPECTED_RETURN
+    EXPECTED_RETURN = {'dependencies': [], 'errors': []}
+    DEPS_RETURN = ([],[])
+    mock_generate_deps.return_value = DEPS_RETURN
 
     # Act
     response = test_client.post(f"/v1/dependencies?type={TYPE}", POST_DATA)
@@ -194,19 +196,21 @@ def test_generate_report_buildlog(
     # Arrange
     POST_DATA = "This is a buildlog"
     TYPE = "buildlog"
-    EXPECTED_RETURN = []
-    mock_generate_deps.return_value = EXPECTED_RETURN
-    mock_generate_findings.return_value = EXPECTED_RETURN
+    EXPECTED_GENERATE_RETURNS = ([],[])
+    mock_generate_deps.return_value = EXPECTED_GENERATE_RETURNS
+    mock_generate_findings.return_value = EXPECTED_GENERATE_RETURNS
+    EXPECTED_RETURN_JSON = {
+        "dependencies": [],
+        "findings": [],
+        "errors": []
+    }
 
     # Act
     response = test_client.post(f"/v1/report?type={TYPE}", POST_DATA)
 
     # Assert
     assert response.status_code == 200
-    assert response.json() == {
-        "dependencies": EXPECTED_RETURN,
-        "findings": EXPECTED_RETURN,
-    }
+    assert response.json() == EXPECTED_RETURN_JSON
     mock_generate_deps.assert_called_once_with(POST_DATA)
     mock_generate_findings.assert_called_once_with(POST_DATA)
 
@@ -253,8 +257,9 @@ def test_generate_buildlog_findings(
     result = microservice.generate_buildlog_findings(MOCK_DOCUMENT)
 
     # Assert
-    assert isinstance(result, list)
-    assert len(result) == 2
+    assert isinstance(result, tuple)
+    assert len(result[0]) == 2
+    assert len(result[1]) == 0
     PARSER_RULES.match.assert_called_once_with(data=MOCK_DOCUMENT)
     FINDING_RULES.match.assert_called_once_with(data=MOCK_DOCUMENT)
 
@@ -277,6 +282,7 @@ def test_generate_buildlog_dependencies(mock_load_parser: mock.MagicMock):
     result = microservice.generate_buildlog_dependencies(MOCK_DOCUMENT)
 
     # Assert
-    assert isinstance(result, list)
-    assert len(result) == 1
+    assert isinstance(result, tuple)
+    assert len(result[0]) == 1
+    assert len(result[1]) == 0
     PARSER_RULES.match.assert_called_once_with(data=MOCK_DOCUMENT)

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -1,0 +1,66 @@
+# Copyright 2020-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import sys
+import time
+from mock import patch, mock_open
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "code"))
+import settings
+
+def test_settings_defaults():
+    # Arrange
+    EXPECTED_ATTRS = ['parser_timeout', 'disabled_parsers']
+    DEFAULT_TIMEOUT = 1
+    DEFAULT_DISABLED = []
+
+    # Act
+    result = settings.Settings()
+
+    # Assert
+    for attr in EXPECTED_ATTRS:
+        getattr(result, attr)
+    assert result.parser_timeout == DEFAULT_TIMEOUT
+    assert result.disabled_parsers == DEFAULT_DISABLED
+
+MOCK_SETTINGS_FILE = """
+parser_timeout: 10
+disabled_parsers:
+- CurlParser
+"""
+
+@patch('settings.isfile')
+@patch("builtins.open", new_callable=mock_open, read_data=MOCK_SETTINGS_FILE)
+def test_settings_load_file(mock_file, mock_isfile):
+    # Arrange
+    MOCK_PATH = "/config/conf.yml"
+    EXPECTED_TIMEOUT = 10
+    EXPECTED_DISABLED = ["CurlParser"]
+    mock_isfile.return_value = True
+
+    # Act
+    result = settings.Settings.load_from_file(MOCK_PATH)
+
+    # Assert
+    mock_isfile.assert_called_once_with(MOCK_PATH)
+    mock_file.assert_called_with(MOCK_PATH, 'r')
+    assert result.parser_timeout == EXPECTED_TIMEOUT
+    assert result.disabled_parsers == EXPECTED_DISABLED
+
+@patch('settings.isfile')
+def test_settings_load_file_nonexistent(mock_isfile):
+    # Arrange
+    MOCK_PATH = "/config/conf.yml"
+    EXPECTED_TIMEOUT = 1
+    EXPECTED_DISABLED = []
+    mock_isfile.return_value = False
+
+    # Act
+    result = settings.Settings.load_from_file(MOCK_PATH)
+
+    # Assert
+    mock_isfile.assert_called_once_with(MOCK_PATH)
+    assert result.parser_timeout == EXPECTED_TIMEOUT
+    assert result.disabled_parsers == EXPECTED_DISABLED

--- a/tests/unit_tests/test_spdx_formatter.py
+++ b/tests/unit_tests/test_spdx_formatter.py
@@ -37,10 +37,16 @@ def mock_dependency():
     return MOCK_DEPENDENCY
 
 @fixture
-def mock_report(mock_finding, mock_dependency):
+def mock_error():
+    MOCK_ERROR = "MockError"
+    return MOCK_ERROR
+
+@fixture
+def mock_report(mock_finding, mock_dependency, mock_error):
     MOCK_REPORT = DocumentReport(
         findings = [mock_finding],
-        dependencies = [mock_dependency]
+        dependencies = [mock_dependency],
+        errors = [mock_error]
     )
     return MOCK_REPORT
 
@@ -56,9 +62,9 @@ def test_proper_inheritance():
     assert issubclass(JSONformatter, EXPECTED_BASE)
     assert issubclass(XMLformatter, EXPECTED_BASE)
 
-def test_JSON_format_findings(mock_finding):
+def test_JSON_format_findings(mock_finding, mock_error):
     # Act
-    result = SPDXJsonFormatter.format_findings([mock_finding])
+    result = SPDXJsonFormatter.format_findings([mock_finding], [mock_error])
 
     # Assert
     assert json.loads(result) # Is valid JSON data
@@ -66,9 +72,9 @@ def test_JSON_format_findings(mock_finding):
     assert isinstance(result_obj, dict) # The return is a dict object
     assert result_obj != {} # Is not blank
 
-def test_JSON_format_dependencies(mock_dependency):
+def test_JSON_format_dependencies(mock_dependency, mock_error):
     # Act
-    result = SPDXJsonFormatter.format_dependencies([mock_dependency])
+    result = SPDXJsonFormatter.format_dependencies([mock_dependency], [mock_error])
 
     # Assert
     assert json.loads(result) # Is valid JSON data
@@ -88,18 +94,18 @@ def test_JSON_format_report(mock_report):
     assert result_obj != [] # Is not blank
     assert len(result_obj) == 2 # It has 1 dependency and 1 base document
 
-def test_XML_format_findings(mock_finding):
+def test_XML_format_findings(mock_finding, mock_error):
     # Act
-    result = SPDXXMLFormatter.format_findings([mock_finding])
+    result = SPDXXMLFormatter.format_findings([mock_finding], [mock_error])
 
     # Assert
     assert xml.etree.ElementTree.fromstring(result) # is valid XML data
     result_obj = xml.etree.ElementTree.fromstring(result)
     assert result_obj.tag == "SpdxDocument"
 
-def test_XML_format_dependencies(mock_dependency):
+def test_XML_format_dependencies(mock_dependency, mock_error):
     # Act
-    result = SPDXXMLFormatter.format_dependencies([mock_dependency])
+    result = SPDXXMLFormatter.format_dependencies([mock_dependency],[mock_error])
 
     # Assert
     documents = result.split('\n---\n')

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,0 +1,54 @@
+# Copyright 2020-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import sys
+import time
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "code"))
+import utils
+
+def test_timeout_success():
+    # Arrange
+    @utils.timeout(10)
+    def mot():
+        time.sleep(1)
+        return "Success"
+
+    # Act
+    result = mot()
+
+    # Assert
+    assert result == "Success"
+
+def test_timeout_timeout():
+    # Arrange
+    @utils.timeout(1)
+    def mot():
+        time.sleep(2)
+        return "Success"
+
+    # Act
+    with pytest.raises(utils.TimeoutExpiredError) as ex:
+        mot()
+
+    # Assert
+    assert isinstance(ex.value.args, tuple)
+    assert isinstance(ex.value.args[0],str)
+    assert "timed out" in ex.value.args[0] 
+    assert ex.value.args[1] == "mot"
+    assert ex.value.args[2] == 1
+
+
+def test_timeout_passes_exception():
+    # Arrange
+    @utils.timeout(1)
+    def mot():
+        raise RuntimeError
+
+    # Act
+    with pytest.raises(RuntimeError):
+        mot()
+
+    # Assert


### PR DESCRIPTION
Implements a basic YAML formatted configuration file with 2 settings:
- disabled_parsers - List of parsers to disable - Default: None
- parser_timeout - Timeout (in seconds) for any individual parser - Default: 1 second

Implements parsing timeout logic for all parsers
Implements error reporting for all timed-out parsers