### PR TITLE
Bump starlette from 0.25.0 to 0.27.0

### DIFF
--- a/code/microservice.py
+++ b/code/microservice.py
@@ -109,7 +109,7 @@ def list_rules():
 async def generate_findings(
     type: Optional[str] = "buildlog",
     format: Optional[str] = "json",
-    request_body: str = Body(..., media_type="text/plain"),
+    request_body: str = Body('', media_type="text/plain"),
 ):
     if type == "buildlog":
         findings, errors =  generate_buildlog_findings(request_body)
@@ -136,7 +136,7 @@ async def generate_findings(
 async def generate_dependencies(
     type: Optional[str] = "buildlog",
     format: Optional[str] = "json",
-    request_body: str = Body(..., media_type="text/plain"),
+    request_body: str = Body('', media_type="text/plain"),
 ):
     if type == "buildlog":
         dependencies, errors =  generate_buildlog_dependencies(request_body)
@@ -164,7 +164,7 @@ async def generate_dependencies(
 async def generate_report(
     type: Optional[str] = "buildlog",
     format: Optional[str] = "json",
-    request_body: str = Body(..., media_type="text/plain"),
+    request_body: str = Body('', media_type="text/plain"),
 ):
     if type == "buildlog":
         dependencies, dep_errors = generate_buildlog_dependencies(request_body)

--- a/code/microservice.py
+++ b/code/microservice.py
@@ -11,7 +11,6 @@ from models import (
 from typing import Any, List, Optional
 from fastapi import FastAPI, Response, HTTPException
 from fastapi.params import Body
-from starlette.requests import Request
 from parsers import ALL_PARSERS
 from utils import timeout, TimeoutExpiredError
 from settings import Settings
@@ -106,17 +105,14 @@ def list_rules():
 
 @microservice_api.post(
     "/v1/findings"
-)  ### TODO: Change to have proper documentation in Swagger once https://github.com/tiangolo/fastapi/issues/1018 is fixed
+)
 async def generate_findings(
     type: Optional[str] = "buildlog",
     format: Optional[str] = "json",
-    request: Request = Body(None, media_type="text/plain"),
+    request_body: str = Body(..., media_type="text/plain"),
 ):
-    request_body = (
-        await request.body()
-    )  # Have to get the request body directly to allow non-JSON body until TODO is fixed ^^^
     if type == "buildlog":
-        findings, errors =  generate_buildlog_findings(request_body.decode())
+        findings, errors =  generate_buildlog_findings(request_body)
         formatter = AVAILABLE_FORMATTERS.get(format, None)
         if not formatter:
             raise HTTPException(
@@ -136,17 +132,14 @@ async def generate_findings(
 
 @microservice_api.post(
     "/v1/dependencies"
-)  ### TODO: Change to have proper documentation in Swagger once https://github.com/tiangolo/fastapi/issues/1018 is fixed
+)
 async def generate_dependencies(
     type: Optional[str] = "buildlog",
     format: Optional[str] = "json",
-    request: Request = Body(None, media_type="text/plain"),
+    request_body: str = Body(..., media_type="text/plain"),
 ):
-    request_body = (
-        await request.body()
-    )  # Have to get the request body directly to allow non-JSON body until TODO is fixed ^^^
     if type == "buildlog":
-        dependencies, errors =  generate_buildlog_dependencies(request_body.decode())
+        dependencies, errors =  generate_buildlog_dependencies(request_body)
         formatter = AVAILABLE_FORMATTERS.get(format, None)
         if not formatter:
             raise HTTPException(
@@ -167,18 +160,15 @@ async def generate_dependencies(
 
 @microservice_api.post(
     "/v1/report"
-)  ### TODO: Change to have proper documentation in Swagger once https://github.com/tiangolo/fastapi/issues/1018 is fixed
+)
 async def generate_report(
     type: Optional[str] = "buildlog",
     format: Optional[str] = "json",
-    request: Request = Body(None, media_type="text/plain"),
+    request_body: str = Body(..., media_type="text/plain"),
 ):
-    request_body = (
-        await request.body()
-    )  # Have to get the request body directly to allow non-JSON body until TODO is fixed ^^^
     if type == "buildlog":
-        dependencies, dep_errors = generate_buildlog_dependencies(request_body.decode())
-        findings, fin_errors = generate_buildlog_findings(request_body.decode())
+        dependencies, dep_errors = generate_buildlog_dependencies(request_body)
+        findings, fin_errors = generate_buildlog_findings(request_body)
         report = DocumentReport(
             dependencies=dependencies,
             findings=findings,

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,8 +1,8 @@
 click==7.1.2
 fastapi>=0.65.2
-h11==0.12.0
+h11>=0.13.0
 pydantic==1.8.2
-starlette==0.25.0
+starlette==0.27.0
 typing-extensions>=3.10.0
 uvicorn==0.13.4
 yara-python==4.0.5

--- a/tests/automated_functional_test/functional_test.py
+++ b/tests/automated_functional_test/functional_test.py
@@ -121,7 +121,7 @@ class FunctionalTestRunner():
         body = test_config.config.input_data
         url = self.API_REPORT_PATH
         try:
-            response = self.api_client.post(url=url,data=body.encode('utf-8'))
+            response = self.api_client.post(url=url, data=body.encode('utf-8'), headers={'Content-Type': 'text/plain'})
             if response.status_code == 200:
                 return response.json()
             else:

--- a/tests/unit_tests/test_microservice.py
+++ b/tests/unit_tests/test_microservice.py
@@ -134,7 +134,7 @@ def test_generate_findings_buildlog(
     EXPECTED_RETURN = {'errors': [], 'findings': []}
 
     # Act
-    response = test_client.post(url=f"/v1/findings?type={TYPE}", content=POST_DATA)
+    response = test_client.post(url=f"/v1/findings?type={TYPE}", content=POST_DATA, headers={'Content-Type': 'text/plain'})
 
     # Assert
     assert response.status_code == 200
@@ -148,7 +148,7 @@ def test_generate_findings_nonimplemented(test_client: TestClient):
     TYPE = "anotimplementedtypeofgenerator"
 
     # Act
-    response = test_client.post(url=f"/v1/findings?type={TYPE}", content=POST_DATA)
+    response = test_client.post(url=f"/v1/findings?type={TYPE}", content=POST_DATA, headers={'Content-Type': 'text/plain'})
 
     # Assert
     assert response.status_code == http.client.BAD_REQUEST
@@ -166,7 +166,7 @@ def test_generate_deps_buildlog(
     mock_generate_deps.return_value = DEPS_RETURN
 
     # Act
-    response = test_client.post(url=f"/v1/dependencies?type={TYPE}", content=POST_DATA)
+    response = test_client.post(url=f"/v1/dependencies?type={TYPE}", content=POST_DATA, headers={'Content-Type': 'text/plain'})
 
     # Assert
     assert response.status_code == 200
@@ -180,7 +180,7 @@ def test_generate_deps_nonimplemented(test_client: TestClient):
     TYPE = "anotimplementedtypeofgenerator"
 
     # Act
-    response = test_client.post(url=f"/v1/dependencies?type={TYPE}", content=POST_DATA)
+    response = test_client.post(url=f"/v1/dependencies?type={TYPE}", content=POST_DATA, headers={'Content-Type': 'text/plain'})
 
     # Assert
     assert response.status_code == http.client.BAD_REQUEST
@@ -206,7 +206,7 @@ def test_generate_report_buildlog(
     }
 
     # Act
-    response = test_client.post(url=f"/v1/report?type={TYPE}", content=POST_DATA)
+    response = test_client.post(url=f"/v1/report?type={TYPE}", content=POST_DATA, headers={'Content-Type': 'text/plain'})
 
     # Assert
     assert response.status_code == 200
@@ -221,7 +221,7 @@ def test_generate_report_nonimplemented(test_client: TestClient):
     TYPE = "anotimplementedtypeofgenerator"
 
     # Act
-    response = test_client.post(url=f"/v1/report?type={TYPE}", content=POST_DATA)
+    response = test_client.post(url=f"/v1/report?type={TYPE}", content=POST_DATA, headers={'Content-Type': 'text/plain'})
 
     # Assert
     assert response.status_code == http.client.BAD_REQUEST


### PR DESCRIPTION
Changes : 

- Upgrade **starlette** version from `0.25.0`to `0.27.0`
- fastapi is now at `0.95.2` for supporting starlette `0.27.0`
- Added `h11>=0.13.0` because `httpcore 0.17.2` requires `h11<0.15`,`>=0.13`
- Added `request_body` to get the request body directly to allow non-JSON data
- Made changes to `tests/unit_tests/test_microservice.py` for passing `Content-Type` as `text/plain`
- In Swagger UI, users can  now enter the body for the request

For performing post requests with request body we must strictly pass headers with `Content-Type` as `text/plain` for the request to work. This is to prevent CSRF in FastAPI as mentioned here https://github.com/tiangolo/fastapi/pull/3456 and https://github.com/tiangolo/fastapi/security/advisories/GHSA-8h2j-cgx8-6xv7

To allow request Body to parse as non-JSON based on `media_type` the issue is ongoing in https://github.com/tiangolo/fastapi/discussions/9159

Fixes https://github.com/vmware-labs/build-inspector/issues/26

Fixes https://github.com/vmware-labs/build-inspector/security/dependabot/5
