### PR TITLE
chore: bump dependencies with critical vulnerability

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,6 +1,6 @@
 click==7.1.2
-fastapi>=0.65.2
-h11>=0.13.0
+fastapi>=0.88.0
+h11>=0.12.0
 pydantic==1.8.2
 starlette==0.27.0
 typing-extensions>=3.10.0

--- a/tests/automated_functional_test/test_requirements.txt
+++ b/tests/automated_functional_test/test_requirements.txt
@@ -1,4 +1,4 @@
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==2.0.9
 Deprecated==1.2.13
 idna==3.3
@@ -7,6 +7,6 @@ pydantic-yaml==0.5.0
 PyYAML==6.0
 requests==2.31.0
 semver==2.13.0
-typing_extensions==4.0.1
+typing_extensions==4.5.0
 urllib3==1.26.7
 wrapt==1.13.3


### PR DESCRIPTION
This change bumps or changes some critical vulnerabilities based on a dependabot report. 
I'm doing this as a PR because the dependabot PR had some issues that caused testing to fail. 