### PR TITLE
Dependency information in the CycloneDX JSON and XML formats

### DIFF
--- a/code/formatters/cyclonedx.py
+++ b/code/formatters/cyclonedx.py
@@ -1,0 +1,73 @@
+# Copyright 2020-2023 VMware, Inc.
+
+import json
+import uuid
+from typing import List
+from packageurl import PackageURL
+from cyclonedx.model.bom import Bom
+from cyclonedx.output import get_instance
+from cyclonedx.output.xml import XmlV1Dot4
+from cyclonedx.output.json import JsonV1Dot4
+from models import DocumentReport, ExtractedDependency
+from cyclonedx.model.component import Component, ComponentType
+from formatters.base import BaseFormatter, AVAILABLE_FORMATTERS
+
+
+class CycloneDXBaseFormatter(BaseFormatter):
+    @classmethod
+    def create_base_bom(cls, name) -> Bom:
+        bom = Bom()
+        rootComponent = Component(
+            name=name,
+            type=ComponentType.APPLICATION,
+            bom_ref = f"root-{uuid.uuid4()}"  # Unique bom_ref for root component
+        )
+        bom.metadata.component = rootComponent
+        bom.components.add(rootComponent)
+        return bom, rootComponent
+
+    @classmethod
+    def format_dependencies(cls, dependencies: List[ExtractedDependency],  errors: List[str]) -> Bom:
+        unique_name = f'dependency-{uuid.uuid4()}'
+        bom, rootComponent = cls.create_base_bom(unique_name)
+        all_deps = []
+        for dependency in dependencies:
+            component_bom_ref = f"{dependency.name}-{dependency.version}-{uuid.uuid4()}"  # Unique bom_ref for each dependency
+            component = Component(
+                type=ComponentType.LIBRARY,
+                name=dependency.name,
+                version=dependency.version,
+                bom_ref=component_bom_ref,  # Setting bom_ref
+                purl=PackageURL(type=dependency.type, namespace=None, name=dependency.name, version=dependency.version, qualifiers={}, subpath=None)
+            )
+            bom.components.add(component)
+            all_deps.append(component)
+        bom.register_dependency(rootComponent, [component])
+        return bom
+
+
+class CycloneDXJsonFormatter(CycloneDXBaseFormatter):
+    MIME_TYPE = 'application/json'
+
+    @classmethod
+    def format_dependencies(cls, dependencies: List[ExtractedDependency],  errors: List[str]):
+        bom = super().format_dependencies(dependencies, errors)
+        serializedJSON = JsonV1Dot4(bom).output_as_string()
+        return serializedJSON
+
+
+
+class CycloneDXXMLFormatter(CycloneDXBaseFormatter):
+    MIME_TYPE = 'application/xml'
+
+    @classmethod
+    def format_dependencies(cls, dependencies: List[ExtractedDependency],  errors: List[str]):
+        bom = super().format_dependencies(dependencies, errors)
+        serializedXML = XmlV1Dot4(bom).output_as_string()
+        return serializedXML
+
+
+
+AVAILABLE_FORMATTERS['cyclonedx'] = CycloneDXJsonFormatter
+AVAILABLE_FORMATTERS['cyclonedx-json'] = CycloneDXJsonFormatter
+AVAILABLE_FORMATTERS['cyclonedx-xml'] = CycloneDXXMLFormatter

--- a/code/microservice.py
+++ b/code/microservice.py
@@ -18,6 +18,7 @@ from settings import Settings
 from formatters.base import AVAILABLE_FORMATTERS
 from formatters.json import *
 from formatters.spdx import *
+from formatters.cyclonedx import *
 from functools import lru_cache
 import http.client
 import logging

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -3,7 +3,7 @@ fastapi>=0.88.0
 h11>=0.12.0
 pydantic==1.8.2
 starlette==0.27.0
-typing-extensions>=3.10.0
+typing-extensions==4.8.0
 uvicorn==0.13.4
 yara-python==4.0.5
 spdx-tools==0.6.1

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -7,3 +7,4 @@ typing-extensions>=3.10.0
 uvicorn==0.13.4
 yara-python==4.0.5
 spdx-tools==0.6.1
+cyclonedx-python-lib==5.1.1

--- a/tests/automated_functional_test/test_requirements.txt
+++ b/tests/automated_functional_test/test_requirements.txt
@@ -1,4 +1,4 @@
-certifi==2023.7.22
+tests/automated_functional_test/test_requirements.txtcertifi==2023.7.22
 charset-normalizer==2.0.9
 Deprecated==1.2.13
 idna==3.3
@@ -7,6 +7,6 @@ pydantic-yaml==0.5.0
 PyYAML==6.0
 requests==2.31.0
 semver==2.13.0
-typing_extensions==4.5.0
+typing_extensions==4.8.0
 urllib3==1.26.18
 wrapt==1.13.3

--- a/tests/automated_functional_test/test_requirements.txt
+++ b/tests/automated_functional_test/test_requirements.txt
@@ -1,4 +1,4 @@
-tests/automated_functional_test/test_requirements.txtcertifi==2023.7.22
+certifi==2023.7.22
 charset-normalizer==2.0.9
 Deprecated==1.2.13
 idna==3.3


### PR DESCRIPTION
**Changes** : 
- Leveraging https://pypi.org/project/cyclonedx-python-lib/ for CycloneDX SBOM format
- CycloneDX output format works for dependencies API `/v1/dependencies?type=buildlog&format=cyclonedx-json`& `/v1/dependencies?type=buildlog&format=cyclonedx-xml` for JSON and XML formats respectively.


**Miscellaneous Issue** :
Encountered 'Doc' import error from the pipeline logs. This was traced out to an issue in fastapi https://github.com/tiangolo/fastapi/discussions/10476

A per suggestion upgraded typing-extension to `typing_extensions==4.8.0`. They have re-introduced `Doc` import back in **Release 4.8.0rc1 (September 7, 2023)** https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-480rc1-september-7-2023